### PR TITLE
Update TranslatableFieldMixin.php

### DIFF
--- a/src/TranslatableFieldMixin.php
+++ b/src/TranslatableFieldMixin.php
@@ -28,7 +28,7 @@ class TranslatableFieldMixin
                         $allTranslations = $resource->getTranslationsArray();
                         $value = [];
                         foreach ($locales as $localeKey => $localeName) {
-                            $value[$localeKey] = $allTranslations[$localeKey][$attribute];
+                            $value[$localeKey] = $allTranslations[$localeKey][$attribute] ?? null;
                         }
                     } catch (Exception $e) {
                         $value = [];


### PR DESCRIPTION
If there is no translation for the field in the DB (manual creation...), the try...catch block fails by not assigning any value even for the locale present. Assigning a null value solves the problem.